### PR TITLE
refactor: remove lodash usages and replace with native JS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@angular/platform-browser": "~17.2.1",
         "@angular/platform-browser-dynamic": "~17.2.1",
         "@angular/router": "~17.2.1",
-        "lodash-es": "^4.17.21",
         "rxjs": "^7.8.1",
         "tslib": "^2.6.2",
         "zone.js": "~0.14.4"
@@ -37,7 +36,6 @@
         "@commitlint/config-conventional": "^18.6.2",
         "@ngneat/spectator": "^16.0.0",
         "@types/jest": "^29.5.12",
-        "@types/lodash-es": "^4.17.12",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
         "@typescript-eslint/parser": "^7.0.1",
         "all-contributors-cli": "^6.26.1",
@@ -6600,21 +6598,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.14.202",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
-      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
-      "dev": true
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -17177,11 +17160,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@angular/platform-browser": "~17.2.1",
     "@angular/platform-browser-dynamic": "~17.2.1",
     "@angular/router": "~17.2.1",
-    "lodash-es": "^4.17.21",
     "rxjs": "^7.8.1",
     "tslib": "^2.6.2",
     "zone.js": "~0.14.4"
@@ -59,7 +58,6 @@
     "@commitlint/config-conventional": "^18.6.2",
     "@ngneat/spectator": "^16.0.0",
     "@types/jest": "^29.5.12",
-    "@types/lodash-es": "^4.17.12",
     "@typescript-eslint/eslint-plugin": "^7.0.1",
     "@typescript-eslint/parser": "^7.0.1",
     "all-contributors-cli": "^6.26.1",

--- a/projects/demo/jest.config.ts
+++ b/projects/demo/jest.config.ts
@@ -6,7 +6,6 @@ const jestConfig = {
   // globalSetup: 'jest-preset-angular/global-setup',
   moduleNameMapper: {
     'ng-in-viewport': '<rootDir>/../ng-in-viewport/src/public-api.ts',
-    '^lodash-es$': 'lodash',
   },
   setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
   coverageDirectory: '<rootDir>/../../coverage/demo',

--- a/projects/example/jest.config.ts
+++ b/projects/example/jest.config.ts
@@ -6,7 +6,6 @@ const jestConfig = {
   // globalSetup: 'jest-preset-angular/global-setup',
   moduleNameMapper: {
     'ng-in-viewport': '<rootDir>/../ng-in-viewport/src/public-api.ts',
-    '^lodash-es$': 'lodash',
   },
   setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
   coverageDirectory: '<rootDir>/../../coverage/demo',

--- a/projects/ng-in-viewport/jest.config.ts
+++ b/projects/ng-in-viewport/jest.config.ts
@@ -4,7 +4,6 @@ const jestConfig: Config = {
   displayName: 'ng-in-viewport',
   preset: 'jest-preset-angular',
   // globalSetup: 'jest-preset-angular/global-setup',
-  moduleNameMapper: { '^lodash-es$': 'lodash' },
   setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
   coverageDirectory: '<rootDir>/../../coverage/ng-in-viewport',
   coverageProvider: 'v8',

--- a/projects/ng-in-viewport/ng-package.json
+++ b/projects/ng-in-viewport/ng-package.json
@@ -3,6 +3,5 @@
   "dest": "../../dist/ng-in-viewport",
   "lib": {
     "entryFile": "src/public-api.ts"
-  },
-  "allowedNonPeerDependencies": ["lodash-es"]
+  }
 }

--- a/projects/ng-in-viewport/package.json
+++ b/projects/ng-in-viewport/package.json
@@ -33,7 +33,6 @@
     "url": "https://github.com/k3nsei"
   },
   "dependencies": {
-    "lodash-es": "^4.17.21",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {

--- a/projects/ng-in-viewport/src/lib/services/in-viewport.service.spec.ts
+++ b/projects/ng-in-viewport/src/lib/services/in-viewport.service.spec.ts
@@ -1,16 +1,16 @@
 import { NgZone } from '@angular/core';
 import { SpectatorService, createServiceFactory } from '@ngneat/spectator/jest';
-import { uniqueId } from 'lodash';
 import { Subscription } from 'rxjs';
 
 import { ObserverCache } from '../utils';
+import { generateRandomUID } from '../utils/generate-random-uid';
 import { Config } from '../values';
 
 import { InViewportService } from './in-viewport.service';
 
 const createNode = (): HTMLDivElement => {
   return Object.assign(document.createElement('div'), {
-    className: uniqueId('c-'),
+    className: generateRandomUID('c-'),
   });
 };
 

--- a/projects/ng-in-viewport/src/lib/utils/generate-random-uid.spec.ts
+++ b/projects/ng-in-viewport/src/lib/utils/generate-random-uid.spec.ts
@@ -1,0 +1,44 @@
+import { generateRandomUID } from './generate-random-uid';
+
+describe('GIVEN generateRandomUID', () => {
+  describe('WHEN generating UID`', () => {
+    it('THEN result should be a string', () => {
+      const id = generateRandomUID();
+      expect(typeof id).toBe('string');
+    });
+  });
+
+  describe('WHEN generating multiple UIDs', () => {
+    it('THEN it should generate a unique ID each time it is called', () => {
+      const id1 = generateRandomUID();
+      const id2 = generateRandomUID();
+      expect(id1).not.toEqual(id2);
+    });
+  });
+
+  describe('WHEN getting UID with prefix set to `test-`', () => {
+    it('THEN it should include the specified prefix', () => {
+      const prefix = 'test-';
+      const id = generateRandomUID(prefix);
+      expect(id.startsWith(prefix)).toBe(true);
+    });
+  });
+
+  describe('WHEN specifying a length and prefix', () => {
+    it('THEN it should generate an UID of the correct length when a prefix is specified', () => {
+      const prefix = 'test-';
+      const length = 10;
+      const id = generateRandomUID(prefix, length);
+      // Total length = prefix length + specified length
+      expect(id.length).toBe(prefix.length + length);
+    });
+  });
+
+  describe('WHEN specifying just length', () => {
+    it('THEN it should generate an ID of the correct length when no prefix is specified', () => {
+      const length = 10;
+      const id = generateRandomUID('', length);
+      expect(id.length).toBe(length);
+    });
+  });
+});

--- a/projects/ng-in-viewport/src/lib/utils/generate-random-uid.ts
+++ b/projects/ng-in-viewport/src/lib/utils/generate-random-uid.ts
@@ -1,0 +1,6 @@
+export function generateRandomUID(prefix = '', length = 8) {
+  // Generate a random string of specified length
+  const randomPart = [...Array(length)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
+  // Return the concatenated prefix and the random string
+  return `${prefix}${randomPart}`;
+}

--- a/projects/ng-in-viewport/src/lib/values/check-fn.ts
+++ b/projects/ng-in-viewport/src/lib/values/check-fn.ts
@@ -1,4 +1,4 @@
-import { isFunction, isNil, uniqueId } from 'lodash-es';
+import { generateRandomUID } from '../utils/generate-random-uid';
 
 import { Config } from './config';
 
@@ -38,12 +38,12 @@ export class CheckFn<T = any> {
   }
 
   constructor(value: InViewportCheckFn<T> | null | undefined) {
-    this.#value = isFunction(value) ? value : undefined;
+    this.#value = typeof value === 'function' ? value : undefined;
 
     let id = ids.get(value!) ?? fallbackId;
 
-    if (!isNil(value) && !ids.has(value)) {
-      ids.set(value, (id = uniqueId('in-viewport-check-fn-')));
+    if (value !== null && value !== undefined && !ids.has(value)) {
+      ids.set(value, (id = generateRandomUID('in-viewport-check-fn-')));
     }
 
     this.#id = id;

--- a/projects/ng-in-viewport/src/lib/values/partial.ts
+++ b/projects/ng-in-viewport/src/lib/values/partial.ts
@@ -1,5 +1,3 @@
-import { isBoolean } from 'lodash-es';
-
 export class Partial {
   readonly #value: boolean;
 
@@ -8,6 +6,6 @@ export class Partial {
   }
 
   constructor(value: boolean | null | undefined) {
-    this.#value = isBoolean(value) ? value : true;
+    this.#value = typeof value === 'boolean' ? value : true;
   }
 }

--- a/projects/ng-in-viewport/src/lib/values/root-margin.ts
+++ b/projects/ng-in-viewport/src/lib/values/root-margin.ts
@@ -1,5 +1,3 @@
-import { isString } from 'lodash-es';
-
 import { InvalidRootMarginException } from '../exceptions';
 
 export class RootMargin {
@@ -14,7 +12,7 @@ export class RootMargin {
   }
 
   private static parse(value: unknown): Values {
-    const strValue = isString(value) ? value.trim() : '0px';
+    const strValue = typeof value === 'string' ? value.trim() : '0px';
     const values = strValue.split(/\s+/);
 
     if (values.length <= 4 && values.every((val) => /^-?\d*\.?\d+(px|%)$/.test(val))) {

--- a/projects/ng-in-viewport/src/lib/values/root-node.ts
+++ b/projects/ng-in-viewport/src/lib/values/root-node.ts
@@ -1,5 +1,3 @@
-import { isNil } from 'lodash-es';
-
 import { InvalidRootNodeException } from '../exceptions';
 
 export class RootNode {
@@ -14,7 +12,7 @@ export class RootNode {
   }
 
   private static validate(node: unknown): Element | null {
-    if (isNil(node)) {
+    if (node === null || node === undefined) {
       return null;
     }
 

--- a/projects/ng-in-viewport/src/lib/values/threshold.ts
+++ b/projects/ng-in-viewport/src/lib/values/threshold.ts
@@ -1,5 +1,3 @@
-import { isNumber } from 'lodash-es';
-
 import { InvalidThresholdException } from '../exceptions';
 
 export class Threshold {
@@ -26,6 +24,6 @@ export class Threshold {
   }
 
   private static isValid(value: unknown): value is number {
-    return isNumber(value) && value >= 0 && value <= 1;
+    return typeof value === 'number' && value >= 0 && value <= 1;
   }
 }


### PR DESCRIPTION
This PR replaces `lodash` usages by native JS check and simple UID generator.

We are in effort to remove `lodash` from our production dependencies and since we use this library, I figured it would be nice to replace it as it does not rely on anything crucial or complex.